### PR TITLE
update scala, circe-yaml, tapir and iron.

### DIFF
--- a/.g8/module/modules/$moduleFolder$/src/main/scala/pillars/$package$/$Prefix$Loader.scala
+++ b/.g8/module/modules/$moduleFolder$/src/main/scala/pillars/$package$/$Prefix$Loader.scala
@@ -38,7 +38,7 @@ final case class $Prefix$(client: $Prefix$Client) extends Module:
         val probe = new Probe:
             override def component: Component =
                 Component(Component.Name("$lowerCaseModuleName$"), Component.Type.Datastore)
-            override def check: IO[Boolean]    = true.pure[IO]
+            override def check: IO[Boolean]   = true.pure[IO]
         probe.pure[List]
     end probes
 end $Prefix$
@@ -83,10 +83,10 @@ object $Prefix$Config:
     given Codec[$Prefix$Config] = Codec.AsObject.derivedConfigured
 end $Prefix$Config
 
-private type $Prefix$UserConstraint = Not[Blank] DescribedAs "$Prefix$ user must not be blank"
-opaque type $Prefix$User <: String  = String :| $Prefix$UserConstraint
-object $Prefix$User extends RefinedTypeOps[String, $Prefix$UserConstraint, $Prefix$User]
+private type $Prefix$UserConstraint = DescribedAs[Not[Blank], "$Prefix$ user must not be blank"]
+type $Prefix$User                   = $Prefix$User.T
+object $Prefix$User extends RefinedType[String, $Prefix$UserConstraint]
 
-private type $Prefix$PasswordConstraint = Not[Blank] DescribedAs "$Prefix$ password must not be blank"
-opaque type $Prefix$Password <: String  = String :| $Prefix$PasswordConstraint
-object $Prefix$Password extends RefinedTypeOps[String, $Prefix$PasswordConstraint, $Prefix$Password]
+private type $Prefix$PasswordConstraint = DescribedAs[Not[Blank], "$Prefix$ password must not be blank"]
+type $Prefix$Password                   = $Prefix$Password.T
+object $Prefix$Password extends RefinedType[String, $Prefix$PasswordConstraint]

--- a/modules/core/src/main/scala/pillars/Config.scala
+++ b/modules/core/src/main/scala/pillars/Config.scala
@@ -101,8 +101,9 @@ object Config:
         case ParsingError(cause: Throwable)           extends ConfigError(ErrorNumber(2))
 
         override def message: Message = this match
-            case ConfigError.MissingEnvironmentVariable(name) => Message(s"Missing environment variable $name".assume)
+            case ConfigError.MissingEnvironmentVariable(name) =>
+                Message.assume(s"Missing environment variable $name")
             case ConfigError.ParsingError(cause)              =>
-                Message(s"Failed to parse configuration: ${cause.getMessage}".assume)
+                Message.assume(s"Failed to parse configuration: ${cause.getMessage}")
     end ConfigError
 end Config

--- a/modules/core/src/main/scala/pillars/HttpServer.scala
+++ b/modules/core/src/main/scala/pillars/HttpServer.scala
@@ -85,7 +85,9 @@ object HttpServer:
                 yamlName = openApi.yamlName,
                 contextPath = openApi.contextPath,
                 useRelativePaths = openApi.useRelativePaths,
-                showExtensions = openApi.showExtensions
+                showExtensions = openApi.showExtensions,
+                initializerOptions = openApi.initializerOptions,
+                oAuthInitOptions = openApi.oAuthInitOptions
               )
             ).fromServerEndpoints(endpoints, name, infos.version)
         else Nil
@@ -136,7 +138,9 @@ object HttpServer:
             yamlName: String = "pillars.yaml",
             contextPath: List[String] = Nil,
             useRelativePaths: Boolean = true,
-            showExtensions: Boolean = false
+            showExtensions: Boolean = false,
+            initializerOptions: Option[Map[String, String]] = None,
+            oAuthInitOptions: Option[Map[String, String]] = None
         )
     end Config
 end HttpServer

--- a/modules/core/src/main/scala/pillars/Logging.scala
+++ b/modules/core/src/main/scala/pillars/Logging.scala
@@ -39,10 +39,10 @@ object Logging:
             case Format.Json => ScribeCirceJsonSupport.writer(config.output.writer)
             case _           => config.output.writer
 
-    private type BufferSizeConstraint = Positive DescribedAs "Buffer size should be positive"
-    opaque type BufferSize <: Int     = Int :| BufferSizeConstraint
+    private type BufferSizeConstraint = DescribedAs[Positive, "Buffer size should be positive"]
+    type BufferSize                   = BufferSize.T
 
-    object BufferSize extends RefinedTypeOps[Int, BufferSizeConstraint, BufferSize]
+    object BufferSize extends RefinedType[Int, BufferSizeConstraint]
 
     enum Format:
         case Json

--- a/modules/core/src/main/scala/pillars/Observability.scala
+++ b/modules/core/src/main/scala/pillars/Observability.scala
@@ -106,8 +106,8 @@ object Observability:
     end Config
 
     private type ServiceNameConstraint = Not[Blank]
-    opaque type ServiceName <: String  = String :| ServiceNameConstraint
-    private object ServiceName extends RefinedTypeOps[String, ServiceNameConstraint, ServiceName]
+    type ServiceName                   = ServiceName.T
+    object ServiceName extends RefinedType[String, ServiceNameConstraint]
 
     extension [A <: String](value: A)
         def toAttribute(name: String): Attribute[String] = Attribute(name, value)

--- a/modules/core/src/main/scala/pillars/PillarsError.scala
+++ b/modules/core/src/main/scala/pillars/PillarsError.scala
@@ -54,23 +54,23 @@ object PillarsError:
     private[pillars] final case class PayloadTooLarge(maxLength: Long) extends PillarsError:
         override def code: Code              = Code("ERR")
         override def number: ErrorNumber     = ErrorNumber(Int.MaxValue)
-        override def message: Message        = Message(s"Payload limit ($maxLength) exceeded".refineUnsafe)
+        override def message: Message        = Message.assume(s"Payload limit ($maxLength) exceeded")
         override def status: StatusCode      = StatusCode.PayloadTooLarge
         override def details: Option[String] = Some(s"Payload limit ($maxLength) exceeded")
     end PayloadTooLarge
 
-    private type CodeConstraint = (Not[Empty] & LettersUpperCase) DescribedAs "Code cannot be empty"
-    opaque type Code <: String  = String :| CodeConstraint
+    private type CodeConstraint = DescribedAs[(Not[Empty] & LettersUpperCase), "Code cannot be empty"]
+    type Code                   = Code.T
 
-    object Code extends RefinedTypeOps[String, CodeConstraint, Code]
+    object Code extends RefinedType[String, CodeConstraint]
 
-    private type MessageConstraint = Not[Empty] DescribedAs "Message cannot be empty"
-    opaque type Message <: String  = String :| MessageConstraint
+    private type MessageConstraint = DescribedAs[Not[Empty], "Message cannot be empty"]
+    type Message                   = Message.T
 
-    object Message extends RefinedTypeOps[String, MessageConstraint, Message]
+    object Message extends RefinedType[String, MessageConstraint]
 
-    private type ErrorNumberConstraint = Positive DescribedAs "Number must be strictly positive"
-    opaque type ErrorNumber <: Int     = Int :| ErrorNumberConstraint
+    private type ErrorNumberConstraint = DescribedAs[Positive, "Number must be strictly positive"]
+    type ErrorNumber                   = ErrorNumber.T
 
-    object ErrorNumber extends RefinedTypeOps[Int, ErrorNumberConstraint, ErrorNumber]
+    object ErrorNumber extends RefinedType[Int, ErrorNumberConstraint]
 end PillarsError

--- a/modules/core/src/main/scala/pillars/app.scala
+++ b/modules/core/src/main/scala/pillars/app.scala
@@ -40,16 +40,19 @@ abstract class IOApp(override val modules: ModuleSupport*) extends App(modules*)
 
 object App:
     private type NameConstraint = Not[Blank]
-    opaque type Name <: String  = String :| NameConstraint
-    object Name extends RefinedTypeOps[String, NameConstraint, Name]
+    type Name                   = Name.T
+    object Name extends RefinedType[String, NameConstraint]
 
     private type VersionConstraint = SemanticVersion
-    opaque type Version <: String  = String :| VersionConstraint
-    object Version extends RefinedTypeOps[String, VersionConstraint, Version]
+    type Version                   = Version.T
+    object Version extends RefinedType[String, VersionConstraint]
 
     private type DescriptionConstraint = Not[Blank]
-    opaque type Description <: String  = String :| DescriptionConstraint
-    object Description extends RefinedTypeOps[String, DescriptionConstraint, Description]
+    type Description                   = Description.T
+    object Description extends RefinedType[String, DescriptionConstraint]
+    def apply(value: String): Description         = value.asInstanceOf[Description]
+    def unapply(description: Description): String = description.asInstanceOf[String]
+    def assume(description: Description): String  = description.asInstanceOf[String]
 end App
 
 case class AppInfo(name: App.Name, version: App.Version, description: App.Description)
@@ -57,5 +60,5 @@ trait BuildInfo:
     def name: String
     def version: String
     def description: String
-    def toAppInfo: AppInfo = AppInfo(Name(name.assume), Version(version.assume), Description(description.assume))
+    def toAppInfo: AppInfo = AppInfo(Name.assume(name), Version.assume(version), Description.assume(description))
 end BuildInfo

--- a/modules/core/src/main/scala/pillars/graph.scala
+++ b/modules/core/src/main/scala/pillars/graph.scala
@@ -51,7 +51,7 @@ object graph:
         override def message: Message = this match
             case GraphError.CyclicDependencyError      => Message("Cyclic dependency found")
             case GraphError.MissingDependency(missing) =>
-                if missing.size == 1 then Message(s"Missing dependency: ${missing.head}".assume)
-                else Message(s"${missing.size} missing dependencies: ${missing.mkString(", ")}".assume)
+                if missing.size == 1 then Message.assume(s"Missing dependency: ${missing.head}")
+                else Message.assume(s"${missing.size} missing dependencies: ${missing.mkString(", ")}")
     end GraphError
 end graph

--- a/modules/core/src/main/scala/pillars/probes.scala
+++ b/modules/core/src/main/scala/pillars/probes.scala
@@ -31,8 +31,8 @@ object probes:
 
     object Component:
         private type NameConstraint = Not[Blank] & Not[Contain[":"]]
-        opaque type Name <: String  = String :| NameConstraint
-        object Name extends RefinedTypeOps[String, NameConstraint, Name]
+        type Name                   = Name.T
+        object Name extends RefinedType[String, NameConstraint]
 
         enum Type:
             case System, Datastore, Component

--- a/modules/db-doobie-tests/src/main/scala/pillars/db_doobie/tests/DB.scala
+++ b/modules/db-doobie-tests/src/main/scala/pillars/db_doobie/tests/DB.scala
@@ -25,10 +25,10 @@ case class DB(container: JdbcDatabaseContainer) extends ModuleSupport:
 
     private def dbConfig: DatabaseConfig =
         DatabaseConfig(
-          driverClassName = DriverClassName(container.driverClassName.assume),
-          url = JdbcUrl(container.jdbcUrl.assume),
-          username = DatabaseUser(container.username.assume),
-          password = Secret(DatabasePassword(container.password.assume)),
+          driverClassName = DriverClassName.assume(container.driverClassName),
+          url = JdbcUrl.assume(container.jdbcUrl),
+          username = DatabaseUser.assume(container.username),
+          password = Secret(DatabasePassword.assume(container.password)),
           probe = ProbeConfig()
         )
 end DB

--- a/modules/db-doobie/src/main/scala/pillars/db_doobie/db.scala
+++ b/modules/db-doobie/src/main/scala/pillars/db_doobie/db.scala
@@ -113,57 +113,60 @@ object StatementCacheConfig:
     given Codec[StatementCacheConfig] = Codec.AsObject.derivedConfigured
 end StatementCacheConfig
 
-private type SizeConstraint = Positive0 DescribedAs "Size must be positive or zero"
-opaque type Size <: Int     = Int :| SizeConstraint
+private type SizeConstraint = DescribedAs[Positive0, "Size must be positive or zero"]
+type Size                   = Size.T
 
-object Size extends RefinedTypeOps[Int, SizeConstraint, Size]
+object Size extends RefinedType[Int, SizeConstraint]
 
 private type JdbcUrlConstraint =
-    Match["jdbc\\:[^:]+\\:.*"] DescribedAs "Driver class name must in jdbc:<subprotocol>:<subname> format"
-opaque type JdbcUrl <: String  = String :| JdbcUrlConstraint
+    DescribedAs[Match["jdbc\\:[^:]+\\:.*"], "Driver class name must in jdbc:<subprotocol>:<subname> format"]
+type JdbcUrl                   = JdbcUrl.T
 
-object JdbcUrl extends RefinedTypeOps[String, JdbcUrlConstraint, JdbcUrl]
+object JdbcUrl extends RefinedType[String, JdbcUrlConstraint]
 
-private type DriverClassNameConstraint = Not[Blank] DescribedAs "Driver class name must not be blank"
-opaque type DriverClassName <: String  = String :| DriverClassNameConstraint
+private type DriverClassNameConstraint = DescribedAs[Not[Blank], "Driver class name must not be blank"]
+type DriverClassName                   = DriverClassName.T
 
-object DriverClassName extends RefinedTypeOps[String, DriverClassNameConstraint, DriverClassName]
+object DriverClassName extends RefinedType[String, DriverClassNameConstraint]
 
-private type DatabaseNameConstraint = Not[Blank] DescribedAs "Database name must not be blank"
-opaque type DatabaseName <: String  = String :| DatabaseNameConstraint
+private type DatabaseNameConstraint = DescribedAs[Not[Blank], "Database name must not be blank"]
+type DatabaseName                   = DatabaseName.T
 
-object DatabaseName extends RefinedTypeOps[String, DatabaseNameConstraint, DatabaseName]
+object DatabaseName extends RefinedType[String, DatabaseNameConstraint]
 
-private type DatabaseSchemaConstraint = Not[Blank] DescribedAs "Database schema must not be blank"
-opaque type DatabaseSchema <: String  = String :| DatabaseSchemaConstraint
+private type DatabaseSchemaConstraint = DescribedAs[Not[Blank], "Database schema must not be blank"]
+type DatabaseSchema                   = DatabaseSchema.T
 
-object DatabaseSchema extends RefinedTypeOps[String, DatabaseSchemaConstraint, DatabaseSchema]:
+object DatabaseSchema extends RefinedType[String, DatabaseSchemaConstraint]:
     val public: DatabaseSchema  = DatabaseSchema("public")
     val pillars: DatabaseSchema = DatabaseSchema("pillars")
 
 private type DatabaseTableConstraint =
-    (Not[Blank] & Match["""^[a-zA-Z_][0-9a-zA-Z$_]{0,63}$"""]) DescribedAs "Database table must be at most 64 characters (letter, digit, dollar sign or underscore) long and start with a letter or an underscore"
-opaque type DatabaseTable <: String  = String :| DatabaseTableConstraint
+    DescribedAs[
+      (Not[Blank] & Match["""^[a-zA-Z_][0-9a-zA-Z$_]{0,63}$"""]),
+      "Database table must be at most 64 characters (letter, digit, dollar sign or underscore) long and start with a letter or an underscore"
+    ]
+type DatabaseTable                   = DatabaseTable.T
 
-object DatabaseTable extends RefinedTypeOps[String, DatabaseTableConstraint, DatabaseTable]
+object DatabaseTable extends RefinedType[String, DatabaseTableConstraint]
 
-private type DatabaseUserConstraint = Not[Blank] DescribedAs "Database user must not be blank"
-opaque type DatabaseUser <: String  = String :| DatabaseUserConstraint
+private type DatabaseUserConstraint = DescribedAs[Not[Blank], "Database user must not be blank"]
+type DatabaseUser                   = DatabaseUser.T
 
-object DatabaseUser extends RefinedTypeOps[String, DatabaseUserConstraint, DatabaseUser]
+object DatabaseUser extends RefinedType[String, DatabaseUserConstraint]
 
-private type DatabasePasswordConstraint = Not[Blank] DescribedAs "Database password must not be blank"
-opaque type DatabasePassword <: String  = String :| DatabasePasswordConstraint
+private type DatabasePasswordConstraint = DescribedAs[Not[Blank], "Database password must not be blank"]
+type DatabasePassword                   = DatabasePassword.T
 
-object DatabasePassword extends RefinedTypeOps[String, DatabasePasswordConstraint, DatabasePassword]
+object DatabasePassword extends RefinedType[String, DatabasePasswordConstraint]
 
-private type PoolSizeConstraint = GreaterEqual[1] DescribedAs "Pool size must be greater or equal to 1"
-opaque type PoolSize <: Int     = Int :| PoolSizeConstraint
+private type PoolSizeConstraint = DescribedAs[GreaterEqual[1], "Pool size must be greater or equal to 1"]
+type PoolSize                   = PoolSize.T
 
-object PoolSize extends RefinedTypeOps[Int, PoolSizeConstraint, PoolSize]
+object PoolSize extends RefinedType[Int, PoolSizeConstraint]
 
-private type VersionConstraint      = Not[Blank] & Match["^(\\d+\\.\\d+\\.\\d+)$"] DescribedAs
-    "Schema version must be in the form of X.Y.Z"
-opaque type SchemaVersion <: String = String :| VersionConstraint
+private type VersionConstraint =
+    DescribedAs[Not[Blank] & Match["^(\\d+\\.\\d+\\.\\d+)$"], "Schema version must be in the form of X.Y.Z"]
+type SchemaVersion             = SchemaVersion.T
 
-object SchemaVersion extends RefinedTypeOps[String, Not[Blank] & Match["^(\\d+\\.\\d+\\.\\d+)$"], SchemaVersion]
+object SchemaVersion extends RefinedType[String, Not[Blank] & Match["^(\\d+\\.\\d+\\.\\d+)$"]]

--- a/modules/db-migration/src/main/scala/pillars/db/migrations/migrations.scala
+++ b/modules/db-migration/src/main/scala/pillars/db/migrations/migrations.scala
@@ -47,7 +47,7 @@ final case class DBMigration(config: MigrationConfig) extends Module:
             _ <- IO.delay:
                      flyway(
                        DatabaseSchema.pillars,
-                       DatabaseTable(s"${key.name.replaceAll("[^0-9a-zA-Z$_]", "-")}_schema_history".assume),
+                       DatabaseTable.assume(s"${key.name.replaceAll("[^0-9a-zA-Z$_]", "-")}_schema_history"),
                        "classpath:db/migrations"
                      ).migrate()
             _ <- logger.info(s"Migration completed for module ${key.name}")
@@ -100,35 +100,38 @@ object MigrationConfig:
     given Codec[MigrationConfig] = Codec.AsObject.derivedConfigured
 
 private type JdbcUrlConstraint =
-    Match["jdbc\\:[^:]+\\:.*"] DescribedAs "JDBC URL must be in jdbc:<subprotocol>:<subname> format"
-opaque type JdbcUrl <: String  = String :| JdbcUrlConstraint
+    DescribedAs[Match["jdbc\\:[^:]+\\:.*"], "JDBC URL must be in jdbc:<subprotocol>:<subname> format"]
+type JdbcUrl                   = JdbcUrl.T
 
-object JdbcUrl extends RefinedTypeOps[String, JdbcUrlConstraint, JdbcUrl]
+object JdbcUrl extends RefinedType[String, JdbcUrlConstraint]
 
-private type DatabaseNameConstraint = Not[Blank] DescribedAs "Database name must not be blank"
-opaque type DatabaseName <: String  = String :| DatabaseNameConstraint
+private type DatabaseNameConstraint = DescribedAs[Not[Blank], "Database name must not be blank"]
+type DatabaseName                   = DatabaseName.T
 
-object DatabaseName extends RefinedTypeOps[String, DatabaseNameConstraint, DatabaseName]
+object DatabaseName extends RefinedType[String, DatabaseNameConstraint]
 
-private type DatabaseSchemaConstraint = Not[Blank] DescribedAs "Database schema must not be blank"
-opaque type DatabaseSchema <: String  = String :| DatabaseSchemaConstraint
+private type DatabaseSchemaConstraint = DescribedAs[Not[Blank], "Database schema must not be blank"]
+type DatabaseSchema                   = DatabaseSchema.T
 
-object DatabaseSchema extends RefinedTypeOps[String, DatabaseSchemaConstraint, DatabaseSchema]:
+object DatabaseSchema extends RefinedType[String, DatabaseSchemaConstraint]:
     val public: DatabaseSchema  = DatabaseSchema("public")
     val pillars: DatabaseSchema = DatabaseSchema("pillars")
 
 private type DatabaseTableConstraint =
-    (Not[Blank] & Match["""^[a-zA-Z_][0-9a-zA-Z$_]{0,63}$"""]) DescribedAs "Database table must be at most 64 characters (letter, digit, dollar sign or underscore) long and start with a letter or an underscore"
-opaque type DatabaseTable <: String  = String :| DatabaseTableConstraint
+    DescribedAs[
+      (Not[Blank] & Match["""^[a-zA-Z_][0-9a-zA-Z$_]{0,63}$"""]),
+      "Database table must be at most 64 characters (letter, digit, dollar sign or underscore) long and start with a letter or an underscore"
+    ]
+type DatabaseTable                   = DatabaseTable.T
 
-object DatabaseTable extends RefinedTypeOps[String, DatabaseTableConstraint, DatabaseTable]
+object DatabaseTable extends RefinedType[String, DatabaseTableConstraint]
 
-private type DatabaseUserConstraint = Not[Blank] DescribedAs "Database user must not be blank"
-opaque type DatabaseUser <: String  = String :| DatabaseUserConstraint
+private type DatabaseUserConstraint = DescribedAs[Not[Blank], "Database user must not be blank"]
+type DatabaseUser                   = DatabaseUser.T
 
-object DatabaseUser extends RefinedTypeOps[String, DatabaseUserConstraint, DatabaseUser]
+object DatabaseUser extends RefinedType[String, DatabaseUserConstraint]
 
-private type DatabasePasswordConstraint = Not[Blank] DescribedAs "Database password must not be blank"
-opaque type DatabasePassword <: String  = String :| DatabasePasswordConstraint
+private type DatabasePasswordConstraint = DescribedAs[Not[Blank], "Database password must not be blank"]
+type DatabasePassword                   = DatabasePassword.T
 
-object DatabasePassword extends RefinedTypeOps[String, DatabasePasswordConstraint, DatabasePassword]
+object DatabasePassword extends RefinedType[String, DatabasePasswordConstraint]

--- a/modules/db-migration/src/test/scala/pillars/db/migration/MigrationTests.scala
+++ b/modules/db-migration/src/test/scala/pillars/db/migration/MigrationTests.scala
@@ -33,9 +33,9 @@ class MigrationTests extends PillarsFromContainerForEach:
         val url =
             s"jdbc:postgresql://${dbConfig.host}:${dbConfig.port}/${dbConfig.database}"
         MigrationConfig(
-          url = JdbcUrl(url.refineUnsafe),
-          username = DatabaseUser(dbConfig.username.assume),
-          password = Some(Secret(DatabasePassword(dbConfig.password.value.assume)))
+          url = JdbcUrl.assume(url),
+          username = DatabaseUser.assume(dbConfig.username),
+          password = Some(Secret(DatabasePassword.assume(dbConfig.password.value)))
         )
     end configFor
 

--- a/modules/db-skunk-tests/src/main/scala/pillars/db/tests/DB.scala
+++ b/modules/db-skunk-tests/src/main/scala/pillars/db/tests/DB.scala
@@ -36,9 +36,9 @@ object DB extends ModuleTestSupport:
         DatabaseConfig(
           host = Host.fromString(container.host).get,
           port = Port.fromInt(container.container.getMappedPort(5432)).get,
-          database = pillars.db.DatabaseName(container.databaseName.assume),
-          username = pillars.db.DatabaseUser(container.username.assume),
-          password = Secret(pillars.db.DatabasePassword(container.password.assume)),
+          database = pillars.db.DatabaseName.assume(container.databaseName),
+          username = pillars.db.DatabaseUser.assume(container.username),
+          password = Secret(pillars.db.DatabasePassword.assume(container.password)),
           poolSize = PoolSize(10),
           probe = ProbeConfig()
         )

--- a/modules/db-skunk/src/main/scala/pillars/db/db.scala
+++ b/modules/db-skunk/src/main/scala/pillars/db/db.scala
@@ -156,41 +156,44 @@ final case class LoggingConfig(
     timing: Boolean = false
 )
 
-private type DatabaseNameConstraint = Not[Blank] DescribedAs "Database name must not be blank"
-opaque type DatabaseName <: String  = String :| DatabaseNameConstraint
+private type DatabaseNameConstraint = DescribedAs[Not[Blank], "Database name must not be blank"]
+type DatabaseName                   = DatabaseName.T
 
-object DatabaseName extends RefinedTypeOps[String, DatabaseNameConstraint, DatabaseName]
+object DatabaseName extends RefinedType[String, DatabaseNameConstraint]
 
-private type DatabaseSchemaConstraint = Not[Blank] DescribedAs "Database schema must not be blank"
-opaque type DatabaseSchema <: String  = String :| DatabaseSchemaConstraint
+private type DatabaseSchemaConstraint = DescribedAs[Not[Blank], "Database schema must not be blank"]
+type DatabaseSchema                   = DatabaseSchema.T
 
-object DatabaseSchema extends RefinedTypeOps[String, DatabaseSchemaConstraint, DatabaseSchema]:
+object DatabaseSchema extends RefinedType[String, DatabaseSchemaConstraint]:
     val public: DatabaseSchema  = DatabaseSchema("public")
     val pillars: DatabaseSchema = DatabaseSchema("pillars")
 
 private type DatabaseTableConstraint =
-    (Not[Blank] & Match["""^[a-zA-Z_][0-9a-zA-Z$_]{0,63}$"""]) DescribedAs "Database table must be at most 64 characters (letter, digit, dollar sign or underscore) long and start with a letter or an underscore"
-opaque type DatabaseTable <: String  = String :| DatabaseTableConstraint
+    DescribedAs[
+      (Not[Blank] & Match["""^[a-zA-Z_][0-9a-zA-Z$_]{0,63}$"""]),
+      "Database table must be at most 64 characters (letter, digit, dollar sign or underscore) long and start with a letter or an underscore"
+    ]
+type DatabaseTable                   = DatabaseTable.T
 
-object DatabaseTable extends RefinedTypeOps[String, DatabaseTableConstraint, DatabaseTable]
+object DatabaseTable extends RefinedType[String, DatabaseTableConstraint]
 
-private type DatabaseUserConstraint = Not[Blank] DescribedAs "Database user must not be blank"
-opaque type DatabaseUser <: String  = String :| DatabaseUserConstraint
+private type DatabaseUserConstraint = DescribedAs[Not[Blank], "Database user must not be blank"]
+type DatabaseUser                   = DatabaseUser.T
 
-object DatabaseUser extends RefinedTypeOps[String, DatabaseUserConstraint, DatabaseUser]
+object DatabaseUser extends RefinedType[String, DatabaseUserConstraint]
 
-private type DatabasePasswordConstraint = Not[Blank] DescribedAs "Database password must not be blank"
-opaque type DatabasePassword <: String  = String :| DatabasePasswordConstraint
+private type DatabasePasswordConstraint = DescribedAs[Not[Blank], "Database password must not be blank"]
+type DatabasePassword                   = DatabasePassword.T
 
-object DatabasePassword extends RefinedTypeOps[String, DatabasePasswordConstraint, DatabasePassword]
+object DatabasePassword extends RefinedType[String, DatabasePasswordConstraint]
 
-private type PoolSizeConstraint = GreaterEqual[1] DescribedAs "Pool size must be greater or equal to 1"
-opaque type PoolSize <: Int     = Int :| PoolSizeConstraint
+private type PoolSizeConstraint = DescribedAs[GreaterEqual[1], "Pool size must be greater or equal to 1"]
+type PoolSize                   = PoolSize.T
 
-object PoolSize extends RefinedTypeOps[Int, PoolSizeConstraint, PoolSize]
+object PoolSize extends RefinedType[Int, PoolSizeConstraint]
 
-private type VersionConstraint      = Not[Blank] & Match["^(\\d+\\.\\d+\\.\\d+)$"] DescribedAs
-    "Schema version must be in the form of X.Y.Z"
-opaque type SchemaVersion <: String = String :| VersionConstraint
+private type VersionConstraint =
+    DescribedAs[Not[Blank] & Match["^(\\d+\\.\\d+\\.\\d+)$"], "Schema version must be in the form of X.Y.Z"]
+type SchemaVersion             = SchemaVersion.T
 
-object SchemaVersion extends RefinedTypeOps[String, Not[Blank] & Match["^(\\d+\\.\\d+\\.\\d+)$"], SchemaVersion]
+object SchemaVersion extends RefinedType[String, Not[Blank] & Match["^(\\d+\\.\\d+\\.\\d+)$"]]

--- a/modules/example/src/main/scala/example/app.scala
+++ b/modules/example/src/main/scala/example/app.scala
@@ -6,7 +6,6 @@ package example
 
 import cats.effect.*
 import example.build.BuildInfo
-import io.github.iltotore.iron.*
 import pillars.*
 import pillars.db.*
 import pillars.db.migrations.*

--- a/modules/example/src/main/scala/example/model.scala
+++ b/modules/example/src/main/scala/example/model.scala
@@ -7,33 +7,33 @@ package example
 import io.github.iltotore.iron.*
 import io.github.iltotore.iron.constraint.all.*
 
-type UsernameConstraint        = (MinLength[3] & MaxLength[20]) DescribedAs "Must be between 3 and 20 characters"
-opaque type Username <: String = String :| UsernameConstraint
-object Username extends RefinedTypeOps[String, UsernameConstraint, Username]
+type UsernameConstraint = DescribedAs[(MinLength[3] & MaxLength[20]), "Must be between 3 and 20 characters"]
+type Username           = Username.T
+object Username extends RefinedType[String, UsernameConstraint]
 
-type AgeConstraint     = (Positive & Less[150]) DescribedAs "Must be a positive number less than 150"
-opaque type Age <: Int = Int :| AgeConstraint
-object Age extends RefinedTypeOps[Int, AgeConstraint, Age]
+type AgeConstraint = DescribedAs[(Positive & Less[150]), "Must be a positive number less than 150"]
+type Age           = Age.T
+object Age extends RefinedType[Int, AgeConstraint]
 
-type FirstNameConstraint        = Not[Blank] DescribedAs "First name must not be blank"
-opaque type FirstName <: String = String :| FirstNameConstraint
-object FirstName extends RefinedTypeOps[String, FirstNameConstraint, FirstName]
+type FirstNameConstraint = DescribedAs[Not[Blank], "First name must not be blank"]
+type FirstName           = FirstName.T
+object FirstName extends RefinedType[String, FirstNameConstraint]
 
-type LastNameConstraint        = Not[Blank] DescribedAs "Last name must not be blank"
-opaque type LastName <: String = String :| LastNameConstraint
-object LastName extends RefinedTypeOps[String, LastNameConstraint, LastName]
+type LastNameConstraint = DescribedAs[Not[Blank], "Last name must not be blank"]
+type LastName           = LastName.T
+object LastName extends RefinedType[String, LastNameConstraint]
 
-type EmailConstraint        = Match[".*@.*\\..*"] DescribedAs "Must be a valid e-mail"
-opaque type Email <: String = String :| EmailConstraint
-object Email extends RefinedTypeOps[String, EmailConstraint, Email]
+type EmailConstraint = DescribedAs[Match[".*@.*\\..*"], "Must be a valid e-mail"]
+type Email           = Email.T
+object Email extends RefinedType[String, EmailConstraint]
 
-type CountryNameConstraint        = Not[Blank] DescribedAs "Country name must not be blank"
-opaque type CountryName <: String = String :| CountryNameConstraint
-object CountryName extends RefinedTypeOps[String, CountryNameConstraint, CountryName]
+type CountryNameConstraint = DescribedAs[Not[Blank], "Country name must not be blank"]
+type CountryName           = CountryName.T
+object CountryName extends RefinedType[String, CountryNameConstraint]
 
-type CountryCodeConstraint        = (FixedLength[2] & LettersUpperCase) DescribedAs "Country name must not be blank"
-opaque type CountryCode <: String = String :| CountryCodeConstraint
-object CountryCode extends RefinedTypeOps[String, CountryCodeConstraint, CountryCode]
+type CountryCodeConstraint = DescribedAs[(FixedLength[2] & LettersUpperCase), "Country name must not be blank"]
+type CountryCode           = CountryCode.T
+object CountryCode extends RefinedType[String, CountryCodeConstraint]
 
 case class Country(code: CountryCode, name: CountryName, niceName: String)
 

--- a/modules/flags/src/main/scala/pillars/flags/FlagController.scala
+++ b/modules/flags/src/main/scala/pillars/flags/FlagController.scala
@@ -41,7 +41,7 @@ object FlagController:
         override def code: Code = Code("FLAG")
 
         case FlagNotFound(name: Flag)
-            extends FlagError(ErrorNumber(1), StatusCode.NotFound, Message(s"Flag ${name}not found".assume))
+            extends FlagError(ErrorNumber(1), StatusCode.NotFound, Message.assume(s"Flag ${name}not found"))
     end FlagError
 
     object FlagEndpoints:

--- a/modules/flags/src/main/scala/pillars/flags/model.scala
+++ b/modules/flags/src/main/scala/pillars/flags/model.scala
@@ -10,10 +10,10 @@ import io.github.iltotore.iron.constraint.all.*
 final case class FeatureFlag(name: Flag, status: Status):
     def isEnabled: Boolean = status.isEnabled
 
-private type FlagConstraint = Not[Blank] DescribedAs "Name must not be blank"
-opaque type Flag <: String  = String :| FlagConstraint
+private type FlagConstraint = DescribedAs[Not[Blank], "Name must not be blank"]
+type Flag                   = Flag.T
 
-object Flag extends RefinedTypeOps[String, FlagConstraint, Flag]
+object Flag extends RefinedType[String, FlagConstraint]
 
 enum Status:
     case Enabled, Disabled

--- a/modules/rabbitmq-fs2/src/main/scala/pillars/rabbitmq/fs2/rabbitmq.scala
+++ b/modules/rabbitmq-fs2/src/main/scala/pillars/rabbitmq/fs2/rabbitmq.scala
@@ -117,18 +117,18 @@ object RabbitMQConfig:
         )
 end RabbitMQConfig
 
-private type RabbitMQVirtualHostConstraint = Not[Blank] DescribedAs "RabbitMQ virtual host must not be blank"
-opaque type RabbitMQVirtualHost <: String  = String :| RabbitMQVirtualHostConstraint
-object RabbitMQVirtualHost extends RefinedTypeOps[String, RabbitMQVirtualHostConstraint, RabbitMQVirtualHost]
+private type RabbitMQVirtualHostConstraint = DescribedAs[Not[Blank], "RabbitMQ virtual host must not be blank"]
+type RabbitMQVirtualHost                   = RabbitMQVirtualHost.T
+object RabbitMQVirtualHost extends RefinedType[String, RabbitMQVirtualHostConstraint]
 
-private type RabbitMQUserConstraint = Not[Blank] DescribedAs "RabbitMQ user must not be blank"
-opaque type RabbitMQUser <: String  = String :| RabbitMQUserConstraint
-object RabbitMQUser extends RefinedTypeOps[String, RabbitMQUserConstraint, RabbitMQUser]
+private type RabbitMQUserConstraint = DescribedAs[Not[Blank], "RabbitMQ user must not be blank"]
+type RabbitMQUser                   = RabbitMQUser.T
+object RabbitMQUser extends RefinedType[String, RabbitMQUserConstraint]
 
-private type RabbitMQPasswordConstraint = Not[Blank] DescribedAs "RabbitMQ password must not be blank"
-opaque type RabbitMQPassword <: String  = String :| RabbitMQPasswordConstraint
-object RabbitMQPassword extends RefinedTypeOps[String, RabbitMQPasswordConstraint, RabbitMQPassword]
+private type RabbitMQPasswordConstraint = DescribedAs[Not[Blank], "RabbitMQ password must not be blank"]
+type RabbitMQPassword                   = RabbitMQPassword.T
+object RabbitMQPassword extends RefinedType[String, RabbitMQPasswordConstraint]
 
-private type RabbitMQConnectionNameConstraint = Not[Blank] DescribedAs "RabbitMQ connection name must not be blank"
-opaque type RabbitMQConnectionName <: String  = String :| RabbitMQConnectionNameConstraint
-object RabbitMQConnectionName extends RefinedTypeOps[String, RabbitMQConnectionNameConstraint, RabbitMQConnectionName]
+private type RabbitMQConnectionNameConstraint = DescribedAs[Not[Blank], "RabbitMQ connection name must not be blank"]
+type RabbitMQConnectionName                   = RabbitMQConnectionName.T
+object RabbitMQConnectionName extends RefinedType[String, RabbitMQConnectionNameConstraint]

--- a/modules/redis-rediculous/src/main/scala/pillars/redis_rediculous/redis.scala
+++ b/modules/redis-rediculous/src/main/scala/pillars/redis_rediculous/redis.scala
@@ -93,12 +93,12 @@ object RedisConfig:
     given Codec[RedisConfig] = Codec.AsObject.derivedConfigured
 end RedisConfig
 
-private type RedisUserConstraint = Not[Blank] DescribedAs "Redis user must not be blank"
-opaque type RedisUser <: String  = String :| RedisUserConstraint
+private type RedisUserConstraint = DescribedAs[Not[Blank], "Redis user must not be blank"]
+type RedisUser                   = RedisUser.T
 
-object RedisUser extends RefinedTypeOps[String, RedisUserConstraint, RedisUser]
+object RedisUser extends RefinedType[String, RedisUserConstraint]
 
-private type RedisPasswordConstraint = Not[Blank] DescribedAs "Redis password must not be blank"
-opaque type RedisPassword <: String  = String :| RedisPasswordConstraint
+private type RedisPasswordConstraint = DescribedAs[Not[Blank], "Redis password must not be blank"]
+type RedisPassword                   = RedisPassword.T
 
-object RedisPassword extends RefinedTypeOps[String, RedisPasswordConstraint, RedisPassword]
+object RedisPassword extends RefinedType[String, RedisPasswordConstraint]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,12 +1,12 @@
 import sbt.*
 
 object versions {
-    val scala            = "3.3.5"
+    val scala            = "3.6.4"
     // Dependencies
     val cats             = "2.13.0"
     val catsEffect       = "3.6.0"
     val circe            = "0.14.12"
-    val circeYaml        = "0.15.3"
+    val circeYaml        = "0.16.0"
     val decline          = "2.5.0"
     val doobie           = "1.0.0-RC9"
     val flyway           = "11.5.0"
@@ -15,15 +15,14 @@ object versions {
     val http4s           = "0.23.30"
     val http4sNetty      = "0.5.23"
     val ip4s             = "3.6.0"
-    val iron             = "2.6.0"
+    val iron             = "3.0.1"
     val literally        = "1.2.0"
-    val openApiCirce     = "0.11.3"
     val otel4s           = "0.12.0"
     val postgresqlDriver = "42.7.5"
     val rediculous       = "0.5.1"
     val scribe           = "3.16.0"
     val skunk            = "1.0.0-M10"
-    val tapir            = "1.11.20"
+    val tapir            = "1.11.32"
     val testContainers   = "0.43.0"
 
     object munit {


### PR DESCRIPTION
* Update Scala to 3.6.4
* Update circe-yaml to 0.16.0
* Update tapir to 1.11.32
* Update iron to 3.0.1

BREAKING CHANGES:
Due to the update of Iron, Scala version is now
3.6.4 and is not binary compatible with
previous versions.